### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update; \
         geotiff-bin libgeotiff-dev; \
     rm -rf /var/lib/apt/lists/*
 
-ARG CMAKE_VERSION=3.11.0
+ARG CMAKE_VERSION=3.16.9
 RUN cd /tmp; \
     curl -fLO https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz; \
     curl -fLo cmake.txt https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-SHA-256.txt; \


### PR DESCRIPTION
Upgrade cmake to 3.16.9 to support python 3.9

CMake is [hard coded](https://github.com/Kitware/CMake/blob/v3.11.0/Modules/FindPythonLibs.cmake#L77) to only look at certain versions of python, so the base image was upgraded, python got upgraded too, and now CMake needs to be upgraded to support python 3.9, which happened somewhere in the 3.16 version.